### PR TITLE
MQTT Authentication + SSL + clientID/cleanSession

### DIFF
--- a/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
@@ -30,15 +30,51 @@ object MQTTUtils {
    * @param ssc           StreamingContext object
    * @param brokerUrl     Url of remote MQTT publisher
    * @param topic         Topic name to subscribe to
+   */
+  def createStream(
+      ssc: StreamingContext,
+      brokerUrl: String,
+      topic: String
+    ): ReceiverInputDStream[String] = {
+    createStream(ssc, brokerUrl, topic, null, null, null, StorageLevel.MEMORY_AND_DISK_SER_2)
+  }
+
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param ssc           StreamingContext object
+   * @param brokerUrl     Url of remote MQTT publisher
+   * @param topic         Topic name to subscribe to
    * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
    */
   def createStream(
       ssc: StreamingContext,
       brokerUrl: String,
       topic: String,
+      storageLevel: StorageLevel
+    ): ReceiverInputDStream[String] = {
+    createStream(ssc, brokerUrl, topic, null, null, null, storageLevel)
+  }
+
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param ssc           StreamingContext object
+   * @param brokerUrl     Url of remote MQTT publisher
+   * @param topic         Topic name to subscribe to
+   * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param userName      MQTT Username required for SSL communication
+   * @param password      MQTT Password required for SSL communication
+   * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
+   */
+  def createStream(
+      ssc: StreamingContext,
+      brokerUrl: String,
+      topic: String,
+      clientID: String,
+      userName: String,
+      password: String,
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
     ): ReceiverInputDStream[String] = {
-    new MQTTInputDStream(ssc, brokerUrl, topic, storageLevel)
+    new MQTTInputDStream(ssc, brokerUrl, topic, clientID, userName, password, storageLevel)
   }
 
   /**
@@ -59,7 +95,51 @@ object MQTTUtils {
 
   /**
    * Create an input stream that receives messages pushed by a MQTT publisher.
-   * @param jssc      JavaStreamingContext object
+   * @param jssc          JavaStreamingContext object
+   * @param brokerUrl     Url of remote MQTT publisher
+   * @param topic         Topic name to subscribe to
+   * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param userName      MQTT Username required for SSL communication
+   * @param password      MQTT Password required for SSL communication
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      clientID: String,
+      userName: String,
+      password: String
+    ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, brokerUrl, topic, clientID, userName, password)
+  }
+
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param jssc          JavaStreamingContext object
+   * @param brokerUrl     Url of remote MQTT publisher
+   * @param topic         Topic name to subscribe to
+   * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param userName      MQTT Username required for SSL communication
+   * @param password      MQTT Password required for SSL communication
+   * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      clientID: String,
+      userName: String,
+      password: String,
+      storageLevel: StorageLevel
+    ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, brokerUrl, topic, clientID, userName, password, storageLevel)
+  }
+
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param jssc          JavaStreamingContext object
    * @param brokerUrl     Url of remote MQTT publisher
    * @param topic         Topic name to subscribe to
    * @param storageLevel  RDD storage level.
@@ -85,8 +165,28 @@ private[mqtt] class MQTTUtilsPythonHelper {
       jssc: JavaStreamingContext,
       brokerUrl: String,
       topic: String,
+      clientID: String,
+      userName: String,
+      password: String,
       storageLevel: StorageLevel
     ): JavaDStream[String] = {
-    MQTTUtils.createStream(jssc, brokerUrl, topic, storageLevel)
+    MQTTUtils.createStream(jssc, brokerUrl, topic, clientID, userName, password, storageLevel)
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      storageLevel: StorageLevel
+    ): JavaDStream[String] = {
+    MQTTUtils.createStream(jssc, brokerUrl, topic, null, null, null, storageLevel)
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String
+    ): JavaDStream[String] = {
+    MQTTUtils.createStream(jssc, brokerUrl, topic)
   }
 }

--- a/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
+++ b/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
@@ -36,7 +36,7 @@ object MQTTUtils {
       brokerUrl: String,
       topic: String
     ): ReceiverInputDStream[String] = {
-    createStream(ssc, brokerUrl, topic, null, null, null, StorageLevel.MEMORY_AND_DISK_SER_2)
+    createStream(ssc, brokerUrl, topic, null, true, null, null, StorageLevel.MEMORY_AND_DISK_SER_2)
   }
 
   /**
@@ -52,7 +52,7 @@ object MQTTUtils {
       topic: String,
       storageLevel: StorageLevel
     ): ReceiverInputDStream[String] = {
-    createStream(ssc, brokerUrl, topic, null, null, null, storageLevel)
+    createStream(ssc, brokerUrl, topic, null, true, null, null, storageLevel)
   }
 
   /**
@@ -61,6 +61,25 @@ object MQTTUtils {
    * @param brokerUrl     Url of remote MQTT publisher
    * @param topic         Topic name to subscribe to
    * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param cleanSession  MQTT should remember state across restarts and reconnects
+   */
+  def createStream(
+      ssc: StreamingContext,
+      brokerUrl: String,
+      topic: String,
+      clientID: String,
+      cleanSession: Boolean
+    ): ReceiverInputDStream[String] = {
+    createStream(ssc, brokerUrl, topic, clientID, cleanSession)
+  }
+
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param ssc           StreamingContext object
+   * @param brokerUrl     Url of remote MQTT publisher
+   * @param topic         Topic name to subscribe to
+   * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param cleanSession  MQTT should remember state across restarts and reconnects
    * @param userName      MQTT Username required for SSL communication
    * @param password      MQTT Password required for SSL communication
    * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
@@ -70,11 +89,12 @@ object MQTTUtils {
       brokerUrl: String,
       topic: String,
       clientID: String,
+      cleanSession: Boolean,
       userName: String,
       password: String,
       storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK_SER_2
     ): ReceiverInputDStream[String] = {
-    new MQTTInputDStream(ssc, brokerUrl, topic, clientID, userName, password, storageLevel)
+    new MQTTInputDStream(ssc, brokerUrl, topic, clientID, cleanSession, userName, password, storageLevel)
   }
 
   /**
@@ -99,6 +119,7 @@ object MQTTUtils {
    * @param brokerUrl     Url of remote MQTT publisher
    * @param topic         Topic name to subscribe to
    * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param cleanSession  MQTT should remember state across restarts and reconnects
    * @param userName      MQTT Username required for SSL communication
    * @param password      MQTT Password required for SSL communication
    */
@@ -107,11 +128,12 @@ object MQTTUtils {
       brokerUrl: String,
       topic: String,
       clientID: String,
+      cleanSession: Boolean,
       userName: String,
       password: String
     ): JavaReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
-    createStream(jssc.ssc, brokerUrl, topic, clientID, userName, password)
+    createStream(jssc.ssc, brokerUrl, topic, clientID, cleanSession, userName, password)
   }
 
   /**
@@ -120,6 +142,7 @@ object MQTTUtils {
    * @param brokerUrl     Url of remote MQTT publisher
    * @param topic         Topic name to subscribe to
    * @param clientID      MQTT ClientID that identifies this connection uniquely 
+   * @param cleanSession  MQTT should remember state across restarts and reconnects
    * @param userName      MQTT Username required for SSL communication
    * @param password      MQTT Password required for SSL communication
    * @param storageLevel  RDD storage level. Defaults to StorageLevel.MEMORY_AND_DISK_SER_2.
@@ -129,12 +152,13 @@ object MQTTUtils {
       brokerUrl: String,
       topic: String,
       clientID: String,
+      cleanSession: Boolean,
       userName: String,
       password: String,
       storageLevel: StorageLevel
     ): JavaReceiverInputDStream[String] = {
     implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
-    createStream(jssc.ssc, brokerUrl, topic, clientID, userName, password, storageLevel)
+    createStream(jssc.ssc, brokerUrl, topic, clientID, cleanSession, userName, password, storageLevel)
   }
 
   /**
@@ -166,11 +190,22 @@ private[mqtt] class MQTTUtilsPythonHelper {
       brokerUrl: String,
       topic: String,
       clientID: String,
+      cleanSession: Boolean,
       userName: String,
       password: String,
       storageLevel: StorageLevel
     ): JavaDStream[String] = {
-    MQTTUtils.createStream(jssc, brokerUrl, topic, clientID, userName, password, storageLevel)
+    MQTTUtils.createStream(jssc, brokerUrl, topic, clientID, cleanSession, userName, password, storageLevel)
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      clientID: String,
+      cleanSession: Boolean
+    ): JavaDStream[String] = {
+    MQTTUtils.createStream(jssc, brokerUrl, topic, clientID, cleanSession, null, null)
   }
 
   def createStream(
@@ -179,7 +214,7 @@ private[mqtt] class MQTTUtilsPythonHelper {
       topic: String,
       storageLevel: StorageLevel
     ): JavaDStream[String] = {
-    MQTTUtils.createStream(jssc, brokerUrl, topic, null, null, null, storageLevel)
+    MQTTUtils.createStream(jssc, brokerUrl, topic, null, true, null, null, storageLevel)
   }
 
   def createStream(


### PR DESCRIPTION
Adds the following features:
- User/Passwd Authentication
- Secured TLSv1.2 connection if brokerUrl.startsWith("ssl://localhost:8883")
- Ability to specify the clientID and the cleanSession flag